### PR TITLE
Enable the use of `CacheKeyGenerator`, `CacheKeyResolver` with Experimental feature supporting Relay Based Pagination.

### DIFF
--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -213,3 +213,18 @@ fun ApolloStore(
     cacheResolver = apolloResolver,
     recordMerger = recordMerger
 )
+
+@ApolloExperimental
+fun ApolloStore(
+    normalizedCacheFactory: NormalizedCacheFactory,
+    cacheKeyGenerator: CacheKeyGenerator,
+    metadataGenerator: MetadataGenerator,
+    cacheResolver: CacheResolver,
+    recordMerger: RecordMerger = DefaultRecordMerger
+): ApolloStore = DefaultApolloStore(
+    normalizedCacheFactory = normalizedCacheFactory,
+    cacheKeyGenerator = cacheKeyGenerator,
+    metadataGenerator = metadataGenerator,
+    recordMerger = recordMerger,
+    cacheResolver = cacheResolver
+)

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -131,6 +131,29 @@ fun ApolloClient.Builder.normalizedCache(
       ), writeToCacheAsynchronously)
 }
 
+@ApolloExperimental
+@JvmOverloads
+@JvmName("configureApolloClientBuilder3")
+fun ApolloClient.Builder.normalizedCache(
+    normalizedCacheFactory: NormalizedCacheFactory,
+    cacheKeyGenerator: CacheKeyGenerator,
+    metadataGenerator: MetadataGenerator,
+    cacheKeyResolver: CacheResolver,
+    recordMerger: RecordMerger,
+    writeToCacheAsynchronously: Boolean = false
+): ApolloClient.Builder {
+  return  store(
+      ApolloStore(
+          normalizedCacheFactory = normalizedCacheFactory,
+          cacheKeyGenerator = cacheKeyGenerator,
+          metadataGenerator = metadataGenerator,
+          cacheResolver = cacheKeyResolver,
+          recordMerger
+      ),
+      writeToCacheAsynchronously
+  )
+}
+
 @JvmName("-logCacheMisses")
 fun ApolloClient.Builder.logCacheMisses(
     log: (String) -> Unit = { println(it) },


### PR DESCRIPTION
## Problem
There are APIs that enable merging of all the `edges` of a Paginated Response in a single record by ignoring the pagination arguments.
However, using this feature requires the usage the `FieldPolicyApolloResolver`.
It would be nice to extend this the APIs so that it can be used with `CacheKeyResolver` instead.